### PR TITLE
Fixes issue 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/11ty/indieweb-avatar#readme",
   "dependencies": {
     "@11ty/eleventy-fetch": "^3.0.0",
-    "@11ty/eleventy-img": "^1.0.0-beta.2",
+    "@11ty/eleventy-img": "^2.0.1",
     "@netlify/functions": "^0.7.2",
     "cheerio": "^1.0.0-rc.10",
     "ico-to-png": "^0.2.1",


### PR DESCRIPTION
Updates `@11ty/eleventy-img`. The latest version, `v2.0.1`, fixes #11.