### PR TITLE
Recognize `.ico` files with a search query

### DIFF
--- a/functions/avatar/avatarHtml.js
+++ b/functions/avatar/avatarHtml.js
@@ -96,7 +96,10 @@ class AvatarHtml {
 
     let relIcons = this.findRelIcons();
     if(relIcons.length) {
-      if(relIcons[0].type === "x-icon" || relIcons[0].href && relIcons[0].href.endsWith(".ico")) {
+      const isIco = relIcons[0].type === 'x-icon'
+        || relIcons[0].href.split(/[#?]/)[0].endsWith('.ico');
+
+      if(isIco) {
         let pngBuffer = await this.convertIcoToPng(relIcons[0].href, width);
         return this.optimizeAvatar(pngBuffer, width, "png");
       } else {

--- a/test.js
+++ b/test.js
@@ -6,7 +6,9 @@ const AvatarHtml = require("./functions/avatar/avatarHtml");
   // let url = "https://www.youtube.com/watch?v=eRRkvI-w5Ik";
   // let url = "https://lynnandtonic.com";
   // let url = "https://sarah.dev/";
-  let url = "https://changelog.com/jsparty/217";
+  // let url = "https://changelog.com/jsparty/217";
+  let url = "https://everyday.app/" // [favicon] ico with search params
+
   console.log( url );
   let avatar = new AvatarHtml(url);
   let html = await avatar.fetch();


### PR DESCRIPTION
Ignore a URL's search query and/or hash segment when checking the favicon's extension.
