### PR TITLE
Add ttl to generated image response, fixes #14

### DIFF
--- a/functions/avatar/index.js
+++ b/functions/avatar/index.js
@@ -3,8 +3,10 @@ const AvatarHtml = require("./avatarHtml.js");
 
 const IMAGE_WIDTH = 60;
 const IMAGE_HEIGHT = 60;
+const IMAGE_TTL = 1 * 7 * 24 * 60 * 60; // 1 week in seconds
 const FALLBACK_IMAGE_FORMAT = "png";
 
+/** @type {import('@netlify/functions').Handler} */
 async function handler(event, context) {
   // e.g. /https%3A%2F%2Fwww.11ty.dev%2F/
   let pathSplit = event.path.split("/").filter(entry => !!entry);
@@ -29,7 +31,8 @@ async function handler(event, context) {
         "content-type": stat.sourceType,
       },
       body: stat.buffer.toString("base64"),
-      isBase64Encoded: true
+      isBase64Encoded: true,
+      ttl: IMAGE_TTL,
     };
   } catch (error) {
     console.log("Error", error);


### PR DESCRIPTION
I wasn't sure if the fallback image should have it too, if that's not going to change until the next build I guess it doesn't?

I also snuck in a cheeky line to type-hint without TypeScript, I can remove this if you don't want it.

I ran it locally with `netlify-cli`'s dev command and it still generated icons for the 11ty site and my personal one.